### PR TITLE
feat: add option to add package extra args

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ appVersion 1.16.0
 | `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                              |
 | `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                   |
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins. |
+| `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`            |
 
 ### Environment Variables
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,33 +3,33 @@ const path = require('path');
 const yaml = require('js-yaml');
 const execa = require('execa');
 const semver = require('semver');
-const {getInstalledHelmVersion} = require('./utils');
+const {getInstalledHelmVersion, parseExtraArgs} = require('./utils');
 
 module.exports = async (pluginConfig, context) => {
     const logger = context.logger;
 
     if (pluginConfig.registry) {
         if (pluginConfig.isChartMuseum) {
-            await publishChartToChartMuseum(pluginConfig.chartPath);
+            await publishChartToChartMuseum(pluginConfig);
         } else {
             const filePath = path.join(pluginConfig.chartPath, 'Chart.yaml');
     
             const chartYaml = await fsPromises.readFile(filePath);
             const chart = yaml.load(chartYaml);
-            await publishChartToRegistry(pluginConfig.chartPath, pluginConfig.registry, chart.name, chart.version);
+            await publishChartToRegistry(pluginConfig, chart);
         }
         logger.log('Chart successfully published.');
     } else if (pluginConfig.crPublish) {
-        await publishChartUsingCr(pluginConfig.chartPath, pluginConfig.crConfigPath, context)
+        await publishChartUsingCr(pluginConfig, context)
     } else {
         logger.log('Chart not published.');
     }
 };
 
-async function publishChartToChartMuseum(configPath) {
+async function publishChartToChartMuseum({chartPath}) {
     await execa(
         'helm',
-        ['cm-push', configPath, 'semantic-release-helm']
+        ['cm-push', chartPath, 'semantic-release-helm']
     );
     await execa(
         'helm',
@@ -37,17 +37,17 @@ async function publishChartToChartMuseum(configPath) {
     );
 }
 
-async function publishChartToRegistry(configPath, registry, name, version) {
+async function publishChartToRegistry({chartPath, registry, packageArgs}, {name, version}) {
     if (registry) {
         if (registry.startsWith('s3://')) {
             const chartName = `${name}-${version}.tgz`;
             await execa(
                 'helm',
-                ['dependency', 'build', configPath]
+                ['dependency', 'build', chartPath]
             );
             await execa(
                 'helm',
-                ['package', configPath]
+                ['package', chartPath, ...parseExtraArgs(packageArgs)]
             );
             await execa(
                 'helm',
@@ -67,7 +67,7 @@ async function publishChartToRegistry(configPath, registry, name, version) {
             if (semver.gte(helmVersion, '3.7.0')) {
                 const { stdout } = await execa(
                     'helm',
-                    ['package', configPath],
+                    ['package', chartPath, ...parseExtraArgs(packageArgs)],
                     {
                         env: {
                             HELM_EXPERIMENTAL_OCI: 1
@@ -90,7 +90,7 @@ async function publishChartToRegistry(configPath, registry, name, version) {
             } else {
                 await execa(
                     'helm',
-                    ['chart', 'save', configPath, registry + ':' + version],
+                    ['chart', 'save', chartPath, registry + ':' + version],
                     {
                         env: {
                             HELM_EXPERIMENTAL_OCI: 1
@@ -111,7 +111,7 @@ async function publishChartToRegistry(configPath, registry, name, version) {
     }
 }
 
-async function publishChartUsingCr(chartPath, crConfigPath, context) {
+async function publishChartUsingCr({chartPath, crConfigPath, packageArgs}, context) {
     const logger = context.logger;
     const env = context.env;
 
@@ -132,7 +132,8 @@ async function publishChartUsingCr(chartPath, crConfigPath, context) {
     const pkgOut = await execa(
         crExec, [
             ...globalArgs,
-            'package', chartPath
+            'package', chartPath,
+            ...parseExtraArgs(packageArgs)
         ]
     )
     logger.info(pkgOut.stdout)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -34,8 +34,13 @@ async function installHelmPlugin(pluginUrl, version) {
     }
 }
 
+function parseExtraArgs(args) {
+    return args ? args.split(" ") : [];
+}
+
 module.exports = {
     getInstalledHelmVersion,
     verifyHelmVersion,
-    installHelmPlugin
+    installHelmPlugin,
+    parseExtraArgs
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -35,7 +35,17 @@ async function installHelmPlugin(pluginUrl, version) {
 }
 
 function parseExtraArgs(args) {
-    return args ? args.split(" ") : [];
+    if (!args) {
+      return [];
+    }
+    // match quoted strings and non-quoted substrings
+    const regex = /[^\s"']+|"([^"]*)"|'([^']*)'/g;
+    const result = [];
+    let match;
+    while (match = regex.exec(args)) {
+      result.push(match[1] || match[2] || match[0]);
+    }
+    return result;
 }
 
 module.exports = {


### PR DESCRIPTION
Add option to add package extra args

```js
const pluginConfig = {
  packageArgs: "--key mykey --keyring ~/.gnupg/secring.gpg"
}
```

@alita1991 please give this a try, I published a pre-release [semantic-release-helm3@2.5.0-rc.0](https://www.npmjs.com/package/semantic-release-helm3/v/2.5.0-rc.0)

Closes https://github.com/nflaig/semantic-release-helm/issues/11