### PR TITLE
feat: add option to add helm cm-push args (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,17 @@ appVersion 1.16.0
 
 ### Plugin Config
 
-| Parameter           | Type      | Default | Required | Description                                                                                                      |
-| ------------------- | --------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
-| `chartPath`         | `string`  | `""`    | `true`   | Chart directory, where the _Chart.yaml_ is located.                                                              |
-| `registry`          | `string`  | `""`    | `false`  | URI of a container registry.                                                                                     |
-| `onlyUpdateVersion` | `boolean` | `false` | `false`  | Don't change `appVersion` if this is true. Useful if your chart is in a different git repo than the application. |
-| `crPublish`         | `boolean` | `false` | `false`  | Enable chart-releaser publishing.                                                                                |
-| `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                              |
-| `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                   |
-| `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins. |
-| `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`            |
+| Parameter           | Type      | Default | Required | Description                                                                                                                           |
+|---------------------| --------- | ------- | -------- |---------------------------------------------------------------------------------------------------------------------------------------|
+| `chartPath`         | `string`  | `""`    | `true`   | Chart directory, where the _Chart.yaml_ is located.                                                                                   |
+| `registry`          | `string`  | `""`    | `false`  | URI of a container registry.                                                                                                          |
+| `onlyUpdateVersion` | `boolean` | `false` | `false`  | Don't change `appVersion` if this is true. Useful if your chart is in a different git repo than the application.                      |
+| `crPublish`         | `boolean` | `false` | `false`  | Enable chart-releaser publishing.                                                                                                     |
+| `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                                                   |
+| `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                                        |
+| `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
+| `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
+| `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
 
 ### Environment Variables
 

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -26,10 +26,10 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function publishChartToChartMuseum({chartPath}) {
+async function publishChartToChartMuseum({chartPath, cmPushArgs}) {
     await execa(
         'helm',
-        ['cm-push', chartPath, 'semantic-release-helm']
+        ['cm-push', chartPath, ...parseExtraArgs(cmPushArgs), 'semantic-release-helm']
     );
     await execa(
         'helm',


### PR DESCRIPTION
This adds the options to pass extra arguments to the `helm cm-push` command.

### Example usage:
```typescript
[
    "semantic-release-helm3",
    {
        chartPath: './chart',
        registry: 'https://nexus.domain.tld/repository/department-helm',
        onlyUpdateVersion: true,
        isChartMuseum: true,
        cmPushArgs: `--context-path "/repository/department-helm"`
    }
],
```

I tested my changes via:
* `npm pack` in this repo
* referenced as file in my `package.json` in the application repo`"semantic-release-helm3": "file://./semantic-release-helm3-2.5.1.tgz"` 
* created a dummy commit for `semantic-release`
* tested it without the extra configuration: ` export REGISTRY_USERNAME=*** && export REGISTRY_PASSWORD=***
 && pnpm -r exec semantic-release --ci=false`
* Result: `Method not allowed (405)
* Added the config 
```
cmPushArgs: `--context-path "/repository/department-helm"` 
```
* created another dummy commit for `semantic-release`
* tested it with the new configuration: ` export REGISTRY_USERNAME=*** && export REGISTRY_PASSWORD=***
 && pnpm -r exec semantic-release --ci=false`

The package got pushed 🎉

I am not sure what else needs to be considered for this change.