### PR TITLE
feat: use REGISTRY_HOST env var with fallback to config.registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ appVersion 1.16.0
 Pass credentials through environment variables accordingly:
 
 ```
+export REGISTRY_HOST=<HOST>
 export REGISTRY_USERNAME=<USERNAME>
 export REGISTRY_PASSWORD=<PASSWORD>
 ```

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -7,8 +7,10 @@ const {getInstalledHelmVersion, parseExtraArgs} = require('./utils');
 
 module.exports = async (pluginConfig, context) => {
     const logger = context.logger;
+    const env = context.env;
+    const registryHost = env.REGISTRY_HOST || registryHost;
 
-    if (pluginConfig.registry) {
+    if (registryHost) {
         if (pluginConfig.isChartMuseum) {
             await publishChartToChartMuseum(pluginConfig);
         } else {

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -8,7 +8,7 @@ const {getInstalledHelmVersion, parseExtraArgs} = require('./utils');
 module.exports = async (pluginConfig, context) => {
     const logger = context.logger;
     const env = context.env;
-    const registryHost = env.REGISTRY_HOST || registryHost;
+    const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost) {
         if (pluginConfig.isChartMuseum) {

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -14,7 +14,6 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
-        
         const registryUrl = registryHost.replace("oci://", "").split('/')[0];
         try {
             await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -11,7 +11,7 @@ module.exports = async (pluginConfig, context) => {
         errors.push('Missing argument: chartPath');
     }
 
-    const registryHost = env.REGISTRY_HOST || registryHost;
+    const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
         

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -11,8 +11,11 @@ module.exports = async (pluginConfig, context) => {
         errors.push('Missing argument: chartPath');
     }
 
-    if (pluginConfig.registry && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
-        const registryUrl = pluginConfig.registry.replace("oci://", "").split('/')[0];
+    const registryHost = env.REGISTRY_HOST || registryHost;
+
+    if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
+        
+        const registryUrl = registryHost.replace("oci://", "").split('/')[0];
         try {
             await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
         } catch (error) {
@@ -20,8 +23,8 @@ module.exports = async (pluginConfig, context) => {
         }
     }
 
-    if (pluginConfig.registry && pluginConfig.isChartMuseum) {
-        if (/^https?/i.test(pluginConfig.registry)) {
+    if (registryHost && pluginConfig.isChartMuseum) {
+        if (/^https?/i.test(registryHost)) {
             try {
                 if (env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
                     try {
@@ -32,7 +35,7 @@ module.exports = async (pluginConfig, context) => {
                     }
                 }
 
-                await addChartRepository(pluginConfig.registry, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
+                await addChartRepository(registryHost, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
             } catch (error) {
                 errors.push('Could not add chart repository. Wrong credentials?', error);
             }
@@ -47,7 +50,7 @@ module.exports = async (pluginConfig, context) => {
         }
     }
 
-    if (pluginConfig.registry && pluginConfig.registry.startsWith('s3://')) {
+    if (registryHost && registryHost.startsWith('s3://')) {
         try {
             await installHelmS3Plugin();
         } catch (error) {
@@ -55,7 +58,7 @@ module.exports = async (pluginConfig, context) => {
         }  
 
         try {
-            await verifyS3Credentials(pluginConfig.registry);
+            await verifyS3Credentials(registryHost);
         } catch (error) {
             errors.push('Could not login to S3. Wrong credentials?', error);
         }


### PR DESCRIPTION
Basically, I added this to `publish.js` and `verifyConditions.js`

```js
   const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
```

and a replace all of `pluginConfig.registry` with `registryHost`.

Closes #18