### PR TITLE
feat: allow skipping of registry login command in verifyConditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ appVersion 1.16.0
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
+| `skipRegistryLogin`        | `string`  | `""`    | `false`  | Additional parameter to skip the `helm registry login` in the verifyConditions step |
+
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ appVersion 1.16.0
 | `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                                                   |
 | `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                                        |
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
-| `skipRegistryLogin` | `boolean` | `false` | `false`  | Skip the `helm registry login` command in the verifyConditions step                                                                           |
+| `skipRegistryLogin` | `boolean` | `false` | `false`  | Skip the `helm registry login` command in the verifyConditions step.                                                                           |
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ appVersion 1.16.0
 | `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                                                   |
 | `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                                        |
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
-| `skipRegistryLogin` | `boolean` | `false` | `false`  | Skip the `helm registry login` in the verifyConditions step                                                                           |
+| `skipRegistryLogin` | `boolean` | `false` | `false`  | Skip the `helm registry login` command in the verifyConditions step                                                                           |
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ appVersion 1.16.0
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
-| `skipRegistryLogin`        | `string`  | `""`    | `false`  | Additional parameter to skip the `helm registry login` in the verifyConditions step |
+| `skipRegistryLogin`        | `boolean`  | `""`    | `false`  | Additional parameter to skip the `helm registry login` in the verifyConditions step |
 
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ appVersion 1.16.0
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
 
-
 ### Environment Variables
 
 Pass credentials through environment variables accordingly:

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ appVersion 1.16.0
 | `crConfigPath`      | `string`  | `""`    | `false`  | Path to .ct.yaml chart-releaser configuration file.                                                                                   |
 | `isChartMuseum`     | `boolean` | `false` | `false`  | Enable ChartMuseum publishing.                                                                                                        |
 | `populateChangelog` | `boolean` | `false` | `false`  | Populate `artifacthub.io/changes` annotations with notes produced by `@semantic-release/release-notes-generator` compatible plugins.  |
+| `skipRegistryLogin` | `boolean` | `false` | `false`  | Skip the `helm registry login` in the verifyConditions step                                                                           |
 | `packageArgs`       | `string`  | `""`    | `false`  | Additional parameters for the helm package command, e.g. `--key mykey --keyring ~/.gnupg/secring.gpg`                                 |
 | `cmPushArgs`        | `string`  | `""`    | `false`  | Additional parameters for the helm cm-push command (only relevant if `isChartMuseum` is set to true) e.g. `--context-path /repo/path` |
-| `skipRegistryLogin`        | `boolean`  | `""`    | `false`  | Additional parameter to skip the `helm registry login` in the verifyConditions step |
 
 
 ### Environment Variables

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -13,11 +13,10 @@ module.exports = async (pluginConfig, context) => {
 
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
-    if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
+    if (registryHost && !pluginConfig.skipRegistryLogin && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
         const registryUrl = registryHost.replace("oci://", "").split('/')[0];
         try {
-            if (pluginConfig.skipRegistryLogin) return;
-            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWOR);
+            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
         } catch (error) {
             errors.push('Could not login to registry. Wrong credentials?', error);
         }

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -16,7 +16,8 @@ module.exports = async (pluginConfig, context) => {
     if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
         const registryUrl = registryHost.replace("oci://", "").split('/')[0];
         try {
-            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD, pluginConfig.skipRegistryLogin);
+            if (pluginConfig.skipRegistryLogin) return;
+            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWOR);
         } catch (error) {
             errors.push('Could not login to registry. Wrong credentials?', error);
         }
@@ -87,9 +88,7 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function verifyRegistryLogin(registryUrl, registryUsername, registryPassword, skipRegistryLogin) {
-    if (skipRegistryLogin) return;
-
+async function verifyRegistryLogin(registryUrl, registryUsername, registryPassword) {
     await execa(
         'helm',
         ['registry', 'login', '--username', registryUsername, '--password-stdin', registryUrl],

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -16,7 +16,7 @@ module.exports = async (pluginConfig, context) => {
     if (registryHost && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
         const registryUrl = registryHost.replace("oci://", "").split('/')[0];
         try {
-            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
+            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD, pluginConfig.skipRegistryLogin);
         } catch (error) {
             errors.push('Could not login to registry. Wrong credentials?', error);
         }
@@ -87,7 +87,9 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function verifyRegistryLogin(registryUrl, registryUsername, registryPassword) {
+async function verifyRegistryLogin(registryUrl, registryUsername, registryPassword, skipRegistryLogin) {
+    if (skipRegistryLogin) return;
+
     await execa(
         'helm',
         ['registry', 'login', '--username', registryUsername, '--password-stdin', registryUrl],


### PR DESCRIPTION
I need to push to artifactory which does not support the `helm registry login` command, but does work with `helm push`. With this new parameter I can disable the check.

Signed-off-by: Sjouke de Vries <info@sdvservices.nl>