### PR TITLE
fix(verifyconditions): also strip http(s) protocol from registry host for split('/')[0]

### DIFF
--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -14,7 +14,11 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost && !pluginConfig.skipRegistryLogin && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
-        const registryUrl = registryHost.replace("oci://", "").split('/')[0];
+        const registryUrl = registryHost
+            .replace("oci://", "")
+            .replace("http://", "")
+            .replace("https://", "")
+            .split('/')[0];
         try {
             await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
         } catch (error) {

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -14,13 +14,13 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost && !pluginConfig.skipRegistryLogin && !pluginConfig.isChartMuseum && env.REGISTRY_USERNAME && env.REGISTRY_PASSWORD) {
-        const registryUrl = registryHost
+        const domain = registryHost
             .replace("oci://", "")
             .replace("http://", "")
             .replace("https://", "")
             .split('/')[0];
         try {
-            await verifyRegistryLogin(registryUrl, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
+            await verifyRegistryLogin(domain, env.REGISTRY_USERNAME, env.REGISTRY_PASSWORD);
         } catch (error) {
             errors.push('Could not login to registry. Wrong credentials?', error);
         }
@@ -91,10 +91,10 @@ module.exports = async (pluginConfig, context) => {
     }
 };
 
-async function verifyRegistryLogin(registryUrl, registryUsername, registryPassword) {
+async function verifyRegistryLogin(domain, registryUsername, registryPassword) {
     await execa(
         'helm',
-        ['registry', 'login', '--username', registryUsername, '--password-stdin', registryUrl],
+        ['registry', 'login', '--username', registryUsername, '--password-stdin', domain],
         {
             input: registryPassword,
             env: {


### PR DESCRIPTION
http:// and https:// are also valid host prefixes

Signed-off-by: Sjouke de Vries <info@sdvservices.nl>