### PR TITLE
feat: allow chartPath to be set from env with CHART_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ appVersion 1.16.0
 
 ### Environment Variables
 
+Set chart path
+
+```sh
+export CHART_PATH=<dir>
+```
+
 Pass credentials through environment variables accordingly:
 
 ```sh

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -2,8 +2,8 @@ const fsPromises = require('fs').promises;
 const path = require('path');
 const yaml = require('js-yaml');
 
-module.exports = async (pluginConfig, {nextRelease: {version, notes}, logger}) => {
-    const filePath = path.join(pluginConfig.chartPath, 'Chart.yaml');
+module.exports = async (pluginConfig, { nextRelease: { version, notes }, logger, env }) => {
+    const filePath = path.join(env.CHART_PATH || pluginConfig.chartPath, 'Chart.yaml');
 
     const chartYaml = await fsPromises.readFile(filePath);
     const oldChart = yaml.load(chartYaml);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,9 +11,9 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost) {
-        // default to path from env
-        // set the pluginConfig accordingly, because functions use named parameters
-        pluginConfig.chartPath = env.CHART_PATH || pluginConfig.chartPath;;
+        // path from env has precedence
+        // override the pluginConfig accordingly, because functions use named parameters
+        pluginConfig.chartPath = env.CHART_PATH || pluginConfig.chartPath;
 
         if (pluginConfig.isChartMuseum) {
             await publishChartToChartMuseum(pluginConfig);

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -11,6 +11,10 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost) {
+        // default to path from env
+        // set the pluginConfig accordingly, because functions use named parameters
+        pluginConfig.chartPath = env.CHART_PATH || pluginConfig.chartPath;;
+
         if (pluginConfig.isChartMuseum) {
             await publishChartToChartMuseum(pluginConfig);
         } else {
@@ -20,6 +24,7 @@ module.exports = async (pluginConfig, context) => {
             const chart = yaml.load(chartYaml);
             await publishChartToRegistry(pluginConfig, chart, context);
         }
+
         logger.log('Chart successfully published.');
     } else if (pluginConfig.crPublish) {
         await publishChartUsingCr(pluginConfig, context)

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -7,8 +7,8 @@ module.exports = async (pluginConfig, context) => {
 
     const env = context.env;
 
-    if (!pluginConfig.chartPath) {
-        errors.push('Missing argument: chartPath');
+    if (!pluginConfig.chartPath || !env.CHART_PATH) {
+        errors.push('Missing argument: chartPath, set by plugin config chartPath key or CHART_PATH in environment');
     }
 
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -7,7 +7,7 @@ module.exports = async (pluginConfig, context) => {
 
     const env = context.env;
 
-    if (!pluginConfig.chartPath || !env.CHART_PATH) {
+    if (!pluginConfig.chartPath && !env.CHART_PATH) {
         errors.push('Missing argument: chartPath, set by plugin config chartPath key or CHART_PATH in environment');
     }
 


### PR DESCRIPTION
In CI/CD I have multiple versions of the same chart equal to the name of branches, e.g. `charts/production` and `charts/staging`. When the pipeline runs on `staging` I want the chartPath to be `charts/$PIPELINE_BRANCH` and that Chart.yaml to be updated. Following that logic I can use `{ .Chart.Version }` to correspond with the correct version on the release channel


Signed-off-by: Sjouke de Vries <info@sdvservices.nl>