### PR TITLE
fix: convert chart yaml to string before parsing

### DIFF
--- a/lib/publish.js
+++ b/lib/publish.js
@@ -20,7 +20,7 @@ module.exports = async (pluginConfig, context) => {
         } else {
             const filePath = path.join(pluginConfig.chartPath, 'Chart.yaml');
 
-            const chartYaml = await fsPromises.readFile(filePath);
+            const chartYaml = (await fsPromises.readFile(filePath)).toString();
             const chart = yaml.parse(chartYaml);
             await publishChartToRegistry(pluginConfig, chart, context);
         }


### PR DESCRIPTION
@halkeye please check the issue https://github.com/nflaig/semantic-release-helm/issues/28, it does seem like `yaml.parse` expects a string

Closes https://github.com/nflaig/semantic-release-helm/issues/28