### PR TITLE
feat: fallback on current working directory for chart path

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ appVersion 1.16.0
 
 | Parameter           | Type      | Default | Required | Description                                                                                                                           |
 | ------------------- | --------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `chartPath`         | `string`  | `cwd`    | `false`   | Chart directory, where the _Chart.yaml_ is located.  If parameter isn't defined, uses the `CHART_PATH` environment variable.  If that isn't defined, ultimately falls back to semantic-release's current working directory (`cwd`).                                                                                   |
+| `chartPath`         | `string`  | `cwd`    | `false`   | Path to chart directory where _Chart.yaml_ is located. Defaults to the `CHART_PATH` environment variable, or ultimately falls back to current working directory (`cwd`) if neither is set.                                                                                   |
 | `registry`          | `string`  | `""`    | `false`  | URI of a container registry.                                                                                                          |
 | `onlyUpdateVersion` | `boolean` | `false` | `false`  | Don't change `appVersion` if this is true. Useful if your chart is in a different git repo than the application.                      |
 | `crPublish`         | `boolean` | `false` | `false`  | Enable chart-releaser publishing.                                                                                                     |

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ appVersion 1.16.0
 
 | Parameter           | Type      | Default | Required | Description                                                                                                                           |
 | ------------------- | --------- | ------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `chartPath`         | `string`  | `""`    | `true`   | Chart directory, where the _Chart.yaml_ is located.                                                                                   |
+| `chartPath`         | `string`  | `cwd`    | `false`   | Chart directory, where the _Chart.yaml_ is located.  If parameter isn't defined, uses the `CHART_PATH` environment variable.  If that isn't defined, ultimately falls back to semantic-release's current working directory (`cwd`).                                                                                   |
 | `registry`          | `string`  | `""`    | `false`  | URI of a container registry.                                                                                                          |
 | `onlyUpdateVersion` | `boolean` | `false` | `false`  | Don't change `appVersion` if this is true. Useful if your chart is in a different git repo than the application.                      |
 | `crPublish`         | `boolean` | `false` | `false`  | Enable chart-releaser publishing.                                                                                                     |

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -3,7 +3,6 @@ const path = require('path');
 const yaml = require('yaml');
 const { getChartPath } = require('./utils');
 
-
 module.exports = async (pluginConfig, {nextRelease: {version, notes}, logger, env, cwd}) => {
     const filePath = path.join(getChartPath(pluginConfig, {env, cwd}), 'Chart.yaml');
 

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,9 +1,11 @@
 const fsPromises = require('fs').promises;
 const path = require('path');
 const yaml = require('yaml');
+const { getChartPath } = require('./utils');
 
-module.exports = async (pluginConfig, {nextRelease: {version, notes}, logger, env}) => {
-    const filePath = path.join(env.CHART_PATH || pluginConfig.chartPath, 'Chart.yaml');
+
+module.exports = async (pluginConfig, {nextRelease: {version, notes}, logger, env, cwd}) => {
+    const filePath = path.join(getChartPath(pluginConfig, {env, cwd}), 'Chart.yaml');
 
     const chartYaml = await fsPromises.readFile(filePath);
     const doc = yaml.parseDocument(chartYaml.toString());

--- a/lib/prepare.js
+++ b/lib/prepare.js
@@ -1,7 +1,7 @@
 const fsPromises = require('fs').promises;
 const path = require('path');
 const yaml = require('yaml');
-const { getChartPath } = require('./utils');
+const {getChartPath} = require('./utils');
 
 module.exports = async (pluginConfig, {nextRelease: {version, notes}, logger, env, cwd}) => {
     const filePath = path.join(getChartPath(pluginConfig, {env, cwd}), 'Chart.yaml');

--- a/lib/publish.js
+++ b/lib/publish.js
@@ -3,7 +3,7 @@ const path = require('path');
 const yaml = require('yaml');
 const execa = require('execa');
 const semver = require('semver');
-const {getInstalledHelmVersion, parseExtraArgs} = require('./utils');
+const {getInstalledHelmVersion, parseExtraArgs, getChartPath} = require('./utils');
 
 module.exports = async (pluginConfig, context) => {
     const logger = context.logger;
@@ -11,9 +11,8 @@ module.exports = async (pluginConfig, context) => {
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
 
     if (registryHost) {
-        // path from env has precedence
         // override the pluginConfig accordingly, because functions use named parameters
-        pluginConfig.chartPath = env.CHART_PATH || pluginConfig.chartPath;
+        pluginConfig.chartPath = getChartPath(pluginConfig, context);
 
         if (pluginConfig.isChartMuseum) {
             await publishChartToChartMuseum(pluginConfig);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,13 +49,7 @@ function parseExtraArgs(args) {
 }
 
 function getChartPath(pluginConfig, {env, cwd}) {
-    if (env.CHART_PATH) {
-        return env.CHART_PATH;
-    } else if (pluginConfig.chartPath) {
-        return pluginConfig.chartPath;
-    } else {
-        return cwd;
-    }
+    return env.CHART_PATH || pluginConfig.chartPath || cwd;
 }
 
 module.exports = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,9 +48,20 @@ function parseExtraArgs(args) {
     return result;
 }
 
+function getChartPath(pluginConfig, {env, cwd}) {
+    if (env.CHART_PATH) {
+        return env.CHART_PATH;
+    } else if (pluginConfig.chartPath) {
+        return pluginConfig.chartPath;
+    } else {
+        return cwd;
+    }
+}
+
 module.exports = {
     getInstalledHelmVersion,
     verifyHelmVersion,
     installHelmPlugin,
-    parseExtraArgs
+    parseExtraArgs,
+    getChartPath,
 };

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -1,0 +1,34 @@
+const utils = require('././utils')
+
+it('use env var as first choice for chart path', () => {
+  const expected = "foo";
+  const env = {CHART_PATH : expected };
+  const pluginConfig = { chartPath: "bar" };
+  const cwd = "baz"
+
+  const actual = utils.getChartPath(pluginConfig, { env, cwd })
+
+  expect(actual).toBe(expected);
+});
+
+it('use argument as second choice for chart path', () => {
+  const expected = "foo";
+  const env = { CHART_PATH : null };
+  const pluginConfig = { chartPath: expected };
+  const cwd = "baz"
+
+  const actual = utils.getChartPath(pluginConfig, { env, cwd })
+
+  expect(actual).toBe(expected);
+});
+
+it('fallback to current working directory for chart path', () => {
+  const expected = "foo";
+  const env = {CHART_PATH : null };
+  const pluginConfig = { chartPath: null };
+  const cwd = expected;
+
+  const actual = utils.getChartPath(pluginConfig, { env, cwd })
+
+  expect(actual).toBe(expected);
+});

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -6,7 +6,7 @@ module.exports = async (pluginConfig, {env, cwd, logger, options}) => {
     const errors = [];
 
     if (!pluginConfig.chartPath && !env.CHART_PATH) {
-        logger.log('Missing chartPath argument and CHART_PATH env variable.  Falling back to current working dir "%s".', cwd);
+        logger.log('Missing chartPath argument or CHART_PATH env variable.  Falling back to current working dir "%s".', cwd);
     }
 
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;

--- a/lib/verifyConditions.js
+++ b/lib/verifyConditions.js
@@ -2,13 +2,11 @@ const AggregateError = require('aggregate-error');
 const execa = require('execa');
 const {verifyHelmVersion, installHelmPlugin} = require('./utils');
 
-module.exports = async (pluginConfig, context) => {
+module.exports = async (pluginConfig, {env, cwd, logger, options}) => {
     const errors = [];
 
-    const env = context.env;
-
     if (!pluginConfig.chartPath && !env.CHART_PATH) {
-        errors.push('Missing argument: chartPath, set by plugin config chartPath key or CHART_PATH in environment');
+        logger.log('Missing chartPath argument and CHART_PATH env variable.  Falling back to current working dir "%s".', cwd);
     }
 
     const registryHost = env.REGISTRY_HOST || pluginConfig.registry;
@@ -69,7 +67,7 @@ module.exports = async (pluginConfig, context) => {
 
     if (pluginConfig.crPublish) {
         try {
-            await parseGithubRepo(context.options.repositoryUrl)
+            await parseGithubRepo(options.repositoryUrl)
         } catch (error) {
             errors.push('Not a github.com url', error);
         }


### PR DESCRIPTION
Adds the ability to fallback on the `cwd` when no chart path is defined.  This assumes that `semantic-release` is being run in the chart's folder.

Fixes the following issue: https://github.com/nflaig/semantic-release-helm/issues/34